### PR TITLE
Add Dependabot for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
## Summary
- Adds `.github/dependabot.yml` to enable weekly automated version updates for GitHub Actions dependencies (`actions/checkout`, `ludeeus/action-shellcheck`, etc.)

## Test plan
- [ ] Verify Dependabot opens version bump PRs after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)