### PR TITLE
Add Java TLS pattern support

### DIFF
--- a/lib/detect.sh
+++ b/lib/detect.sh
@@ -32,6 +32,12 @@ detect_languages() {
 		detected+=("cpp")
 	fi
 
+	# Java: check for pom.xml, build.gradle, or *.java files
+	if [[ -f "$scan_path/pom.xml" ]] || [[ -f "$scan_path/build.gradle" ]] ||
+		find "$scan_path" -maxdepth 3 -name '*.java' -print -quit 2>/dev/null | grep -q .; then
+		detected+=("java")
+	fi
+
 	if [[ ${#detected[@]} -eq 0 ]]; then
 		log_msg "No supported languages detected in $scan_path"
 		echo ""

--- a/lib/scanner.sh
+++ b/lib/scanner.sh
@@ -19,6 +19,7 @@ build_include_flags() {
 		python) echo "--include=*.py" ;;
 		nodejs) echo "--include=*.js --include=*.mjs --include=*.ts --include=*.mts" ;;
 		cpp) echo "--include=*.cpp --include=*.cc --include=*.cxx --include=*.h --include=*.hpp" ;;
+		java) echo "--include=*.java" ;;
 	esac
 }
 
@@ -30,6 +31,7 @@ build_test_exclude_flags() {
 		python) echo "--exclude=*_test.py --exclude=test_*.py --exclude=conftest.py" ;;
 		nodejs) echo "--exclude=*.test.js --exclude=*.spec.js --exclude=*.test.mjs --exclude=*.spec.mjs --exclude=*.test.ts --exclude=*.spec.ts --exclude=*.test.mts --exclude=*.spec.mts" ;;
 		cpp) echo "--exclude=*_test.cpp --exclude=*_test.cc" ;;
+		java) echo "--exclude=*Test.java --exclude=*Tests.java --exclude=*IT.java" ;;
 	esac
 }
 
@@ -39,6 +41,7 @@ build_lang_exclude_dirs() {
 	case "$lang" in
 		nodejs) echo "--exclude-dir=node_modules --exclude-dir=__tests__" ;;
 		python) echo "--exclude-dir=__pycache__ --exclude-dir=venv --exclude-dir=.venv" ;;
+		java) echo "--exclude-dir=target --exclude-dir=build --exclude-dir=.gradle" ;;
 		*) echo "" ;;
 	esac
 }
@@ -231,6 +234,7 @@ scan_language() {
 		python) patterns_var="PYTHON_PATTERNS" ;;
 		nodejs) patterns_var="NODEJS_PATTERNS" ;;
 		cpp) patterns_var="CPP_PATTERNS" ;;
+		java) patterns_var="JAVA_PATTERNS" ;;
 		*) return 0 ;;
 	esac
 

--- a/patterns/java.sh
+++ b/patterns/java.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# java.sh - Java TLS pattern definitions
+# Format: "id|severity|name|description|regex"
+
+# shellcheck disable=SC2034  # Array is used by scanner.sh via eval
+JAVA_PATTERNS=(
+	"allow-all-hostname-verifier|CRITICAL|ALLOW_ALL HostnameVerifier|Disables hostname verification (MITM vulnerability)|setHostnameVerifier.*ALLOW_ALL|HostnameVerifier.*return[[:space:]]+true"
+	"trust-all-certs|CRITICAL|TrustAllCerts / permissive TrustManager|Custom TrustManager that does not verify certificates (MITM vulnerability)|TrustAllCerts|X509TrustManager[^{]*\{[^}]*checkServerTrusted"
+	"custom-ssl-socket-factory|CRITICAL|setSSLSocketFactory bypass|Sets custom SSLSocketFactory that may bypass verification|setSSLSocketFactory"
+	"unversioned-ssl-context|HIGH|SSLContext.getInstance TLS unversioned|SSLContext.getInstance with bare TLS defaults to oldest supported version|SSLContext\.getInstance\(\"TLS\"\)"
+	"sslcontext-tlsv1|HIGH|SSLContext.getInstance TLSv1|TLS 1.0 has known vulnerabilities (POODLE, BEAST)|SSLContext\.getInstance\(\"TLSv1\"\)"
+	"sslcontext-tlsv11|HIGH|SSLContext.getInstance TLSv1.1|TLS 1.1 has known vulnerabilities|SSLContext\.getInstance\(\"TLSv1\.1\"\)"
+	"enabled-weak-protocols|MEDIUM|setEnabledProtocols weak TLS|Enables deprecated TLS 1.0 or 1.1 protocols|setEnabledProtocols.*TLSv1[^.2-9]|setEnabledProtocols.*TLSv1\.1"
+	"sslcontext-tlsv13|INFO|SSLContext.getInstance TLSv1.3|Forces TLS 1.3 only (may break older clients)|SSLContext\.getInstance\(\"TLSv1\.3\"\)"
+)

--- a/testdata/java/Insecure.java
+++ b/testdata/java/Insecure.java
@@ -1,0 +1,56 @@
+import javax.net.ssl.*;
+import java.security.cert.X509Certificate;
+import java.security.SecureRandom;
+
+public class Insecure {
+
+    // CRITICAL: Allow all hostnames
+    public void disableHostnameVerification(HttpsURLConnection conn) {
+        conn.setHostnameVerifier(ALLOW_ALL_HOSTNAME_VERIFIER);
+    }
+
+    // CRITICAL: Trust all certificates
+    public TrustManager[] createTrustAllCerts() {
+        return new TrustManager[]{
+            new X509TrustManager() {
+                public void checkClientTrusted(X509Certificate[] chain, String authType) {}
+                public void checkServerTrusted(X509Certificate[] chain, String authType) {}
+                public X509Certificate[] getAcceptedIssuers() { return new X509Certificate[0]; }
+            }
+        };
+    }
+
+    // CRITICAL: Custom SSLSocketFactory bypass
+    public void setCustomFactory(HttpsURLConnection conn, SSLSocketFactory factory) {
+        conn.setSSLSocketFactory(factory);
+    }
+
+    // HIGH: Unversioned SSLContext (defaults to old TLS)
+    public SSLContext getDefaultContext() throws Exception {
+        SSLContext ctx = SSLContext.getInstance("TLS");
+        return ctx;
+    }
+
+    // HIGH: TLS 1.0
+    public SSLContext getTls10Context() throws Exception {
+        SSLContext ctx = SSLContext.getInstance("TLSv1");
+        return ctx;
+    }
+
+    // HIGH: TLS 1.1
+    public SSLContext getTls11Context() throws Exception {
+        SSLContext ctx = SSLContext.getInstance("TLSv1.1");
+        return ctx;
+    }
+
+    // MEDIUM: Enable weak protocols
+    public void enableWeakProtocols(SSLSocket socket) {
+        socket.setEnabledProtocols(new String[]{"TLSv1", "TLSv1.1", "TLSv1.2"});
+    }
+
+    // INFO: TLS 1.3 only
+    public SSLContext getTls13Context() throws Exception {
+        SSLContext ctx = SSLContext.getInstance("TLSv1.3");
+        return ctx;
+    }
+}

--- a/tests/test_detect.sh
+++ b/tests/test_detect.sh
@@ -23,6 +23,10 @@ assert_contains "Detects Node.js from .js files" "nodejs" "$result"
 result=$(detect_languages "$ROOT_DIR/testdata/cpp" 2>/dev/null)
 assert_contains "Detects C++ from .cpp files" "cpp" "$result"
 
+# Test: Detect Java from testdata
+result=$(detect_languages "$ROOT_DIR/testdata/java" 2>/dev/null)
+assert_contains "Detects Java from .java files" "java" "$result"
+
 # Test: Empty directory returns nothing
 TEMP_DIR=$(mktemp -d)
 result=$(detect_languages "$TEMP_DIR" 2>/dev/null)

--- a/tests/test_scanner.sh
+++ b/tests/test_scanner.sh
@@ -74,6 +74,20 @@ scan_language "$ROOT_DIR/testdata/cpp" "cpp" "" ""
 assert_greater_than "C++ scan finds critical findings" 0 "$CRITICAL_COUNT"
 assert_greater_than "C++ scan finds total findings" 5 "$(get_findings_count)"
 
+# Reset state for Java
+FINDINGS=()
+CRITICAL_COUNT=0
+HIGH_COUNT=0
+MEDIUM_COUNT=0
+INFO_COUNT=0
+
+# Test: Java scanning finds expected patterns
+source "$ROOT_DIR/patterns/java.sh"
+scan_language "$ROOT_DIR/testdata/java" "java" "" ""
+
+assert_greater_than "Java scan finds critical findings" 0 "$CRITICAL_COUNT"
+assert_greater_than "Java scan finds total findings" 5 "$(get_findings_count)"
+
 # Reset state for exclude patterns test
 FINDINGS=()
 CRITICAL_COUNT=0


### PR DESCRIPTION
## Summary

- Add `patterns/java.sh` with 8 TLS security patterns across all severity levels (CRITICAL, HIGH, MEDIUM, INFO) covering hostname verifier bypasses, trust-all certificate managers, custom SSL socket factories, unversioned/weak SSLContext instances, deprecated protocol enablement, and TLS 1.3 enforcement
- Add `testdata/java/Insecure.java` test fixture that triggers all defined patterns
- Update `lib/detect.sh` to auto-detect Java projects via `pom.xml`, `build.gradle`, or `*.java` files
- Update `lib/scanner.sh` with Java-specific include flags (`*.java`), test exclusions (`*Test.java`, `*Tests.java`, `*IT.java`), and build directory exclusions (`target`, `build`, `.gradle`)
- Add Java scanner and detection tests

## Test plan

- [x] All 65 tests pass via `bash tests/run_tests.sh`
- [x] Java detection test: detects Java from `.java` files
- [x] Java scanner test: finds critical findings > 0 and total findings > 5
- [x] All files pass `shfmt -i 0 -ci` formatting validation
- [ ] CI workflow passes on the PR