### PR TITLE
Add cipher suite, OCP TLS profile, and PQC detection patterns

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A GitHub Action that scans your codebase for TLS configuration anti-patterns and
 
 ## Features
 
-- Detects 34 TLS security anti-patterns across 4 languages
+- Detects 49 TLS security anti-patterns across 5 languages
 - Configurable severity thresholds (critical, high, medium, info)
 - Inline PR annotations on affected lines
 - Job summary with findings table
@@ -118,23 +118,28 @@ See [`.tls-config-lint.example.yml`](.tls-config-lint.example.yml) for a full ex
 
 ## Detected Patterns
 
-### Go (11 patterns)
+### Go (16 patterns)
 
 | ID | Severity | Description |
 |----|----------|-------------|
 | `insecure-skip-verify` | CRITICAL | `InsecureSkipVerify: true` disables certificate verification |
+| `weak-cipher-rc4` | CRITICAL | RC4 cipher suite (completely broken) |
+| `null-cipher` | CRITICAL | NULL cipher suite (no encryption) |
 | `min-version-tls10` | HIGH | `MinVersion` set to TLS 1.0 |
 | `min-version-tls11` | HIGH | `MinVersion` set to TLS 1.1 |
 | `max-version-tls10` | HIGH | `MaxVersion` set to TLS 1.0 |
 | `max-version-tls11` | HIGH | `MaxVersion` set to TLS 1.1 |
+| `weak-cipher-3des` | HIGH | 3DES/CBC cipher suites |
+| `tls-profile-old` | HIGH | Old TLS security profile allows TLS 1.0/1.1 |
 | `max-version-tls12` | MEDIUM | `MaxVersion` set to TLS 1.2 (prevents 1.3) |
+| `tls-profile-custom` | MEDIUM | Custom TLS security profile needs review |
 | `min-version-tls13` | INFO | Forces TLS 1.3 only |
 | `prefer-server-cipher-suites` | INFO | Deprecated in Go 1.17+ |
 | `curve-preferences` | INFO | Explicit curve configuration |
 | `hardcoded-tls-config` | INFO | Hardcoded `tls.Config{}` |
 | `pqc-ml-kem` | INFO | Post-Quantum Cryptography adoption |
 
-### Python (8 patterns)
+### Python (11 patterns)
 
 | ID | Severity | Description |
 |----|----------|-------------|
@@ -144,10 +149,13 @@ See [`.tls-config-lint.example.yml`](.tls-config-lint.example.yml) for a full ex
 | `check-hostname-false` | CRITICAL | `check_hostname = False` |
 | `protocol-tlsv1` | HIGH | Uses `PROTOCOL_TLSv1` (TLS 1.0) |
 | `protocol-tlsv11` | HIGH | Uses `PROTOCOL_TLSv1_1` |
+| `weak-cipher-config` | HIGH | Weak ciphers in SSL context |
 | `max-version-tlsv12` | MEDIUM | Caps at TLS 1.2 |
+| `no-default-ciphers` | MEDIUM | Custom cipher configuration (review needed) |
 | `min-version-tlsv13` | INFO | Forces TLS 1.3 |
+| `pqc-ml-kem` | INFO | Post-Quantum Cryptography adoption |
 
-### Node.js/TypeScript (7 patterns)
+### Node.js/TypeScript (9 patterns)
 
 | ID | Severity | Description |
 |----|----------|-------------|
@@ -156,10 +164,12 @@ See [`.tls-config-lint.example.yml`](.tls-config-lint.example.yml) for a full ex
 | `tlsv1-method` | HIGH | Uses `TLSv1_method` |
 | `tlsv11-method` | HIGH | Uses `TLSv1_1_method` |
 | `min-version-weak` | HIGH | `minVersion` allows TLS 1.0/1.1 |
+| `weak-cipher-config` | HIGH | Weak ciphers in TLS options |
 | `max-version-tlsv12` | MEDIUM | Caps at TLS 1.2 |
+| `honor-cipher-order-false` | MEDIUM | Server doesn't enforce cipher preference |
 | `min-version-tlsv13` | INFO | Forces TLS 1.3 |
 
-### C++ (8 patterns)
+### C++ (10 patterns)
 
 | ID | Severity | Description |
 |----|----------|-------------|
@@ -169,8 +179,26 @@ See [`.tls-config-lint.example.yml`](.tls-config-lint.example.yml) for a full ex
 | `tls11-version` | HIGH | Uses `TLS1_1_VERSION` |
 | `sslv3-method` | HIGH | Uses `SSLv3_method` |
 | `tlsv1-method` | HIGH | Uses `TLSv1_method` |
+| `weak-cipher-list` | HIGH | Weak ciphers via `SSL_CTX_set_cipher_list` |
+| `weak-ciphersuites` | HIGH | Weak ciphers via `SSL_CTX_set_ciphersuites` |
 | `max-proto-tls12` | MEDIUM | Caps at TLS 1.2 |
 | `min-proto-tls13` | INFO | Forces TLS 1.3 |
+
+### Java (11 patterns)
+
+| ID | Severity | Description |
+|----|----------|-------------|
+| `allow-all-hostname-verifier` | CRITICAL | `ALLOW_ALL` HostnameVerifier |
+| `trust-all-certs` | CRITICAL | Permissive TrustManager |
+| `custom-ssl-socket-factory` | CRITICAL | Custom `SSLSocketFactory` bypass |
+| `unversioned-ssl-context` | HIGH | `SSLContext.getInstance("TLS")` defaults to old version |
+| `sslcontext-tlsv1` | HIGH | `SSLContext.getInstance("TLSv1")` |
+| `sslcontext-tlsv11` | HIGH | `SSLContext.getInstance("TLSv1.1")` |
+| `weak-cipher-suite` | HIGH | Weak JSSE cipher suites |
+| `enabled-weak-protocols` | MEDIUM | Enables deprecated TLS protocols |
+| `ssl-socket-factory-default` | MEDIUM | Default `SSLSocketFactory` may use weak ciphers |
+| `sslcontext-tlsv13` | INFO | Forces TLS 1.3 only |
+| `pqc-ml-kem` | INFO | Post-Quantum Cryptography adoption |
 
 ## Built-in Exclusions
 

--- a/lib/config.sh
+++ b/lib/config.sh
@@ -177,14 +177,14 @@ validate_config() {
 		for lang in "${lang_list[@]}"; do
 			lang="${lang// /}"
 			case "$lang" in
-				go | python | nodejs | cpp) ;;
+				go | python | nodejs | cpp | java) ;;
 				*)
 					invalid_langs+=("$lang")
 					;;
 			esac
 		done
 		if [[ ${#invalid_langs[@]} -gt 0 ]]; then
-			log_error "Invalid language(s): ${invalid_langs[*]} (supported: go, python, nodejs, cpp)"
+			log_error "Invalid language(s): ${invalid_langs[*]} (supported: go, python, nodejs, cpp, java)"
 			valid=false
 		fi
 	fi

--- a/patterns/cpp.sh
+++ b/patterns/cpp.sh
@@ -12,4 +12,6 @@ CPP_PATTERNS=(
 	"tlsv1-method|HIGH|TLSv1_method|TLS 1.0 has known vulnerabilities|TLSv1_method[^_]"
 	"max-proto-tls12|MEDIUM|SSL_CTX_set_max_proto_version TLS1_2|Caps maximum TLS version at 1.2|SSL_CTX_set_max_proto_version.*TLS1_2_VERSION"
 	"min-proto-tls13|INFO|SSL_CTX_set_min_proto_version TLS1_3|Forces TLS 1.3 (may break older clients)|SSL_CTX_set_min_proto_version.*TLS1_3_VERSION"
+	"weak-cipher-list|HIGH|Weak OpenSSL cipher list|Weak ciphers configured via SSL_CTX_set_cipher_list|SSL_CTX_set_cipher_list.*(DES|RC4|NULL|EXPORT|eNULL|aNULL)"
+	"weak-ciphersuites|HIGH|Weak TLS 1.3 ciphersuites|Weak ciphers configured via SSL_CTX_set_ciphersuites|SSL_CTX_set_ciphersuites.*(DES|RC4|NULL)"
 )

--- a/patterns/go.sh
+++ b/patterns/go.sh
@@ -15,4 +15,9 @@ GO_PATTERNS=(
 	"curve-preferences|INFO|CurvePreferences|Explicit curve configuration (PQC readiness indicator)|CurvePreferences[[:space:]]*[:=]"
 	"hardcoded-tls-config|INFO|Hardcoded tls.Config|Hardcoded TLS config (review for API server TLS profile adherence)|tls\.Config[[:space:]]*\{"
 	"pqc-ml-kem|INFO|PQC/ML-KEM patterns|Post-Quantum Cryptography adoption (ML-KEM)|(X25519MLKEM|MLKEM768|mlkem768|crypto/mlkem|NewDecapsulationKey|NewEncapsulationKey)"
+	"weak-cipher-3des|HIGH|3DES/CBC cipher suite|3DES and CBC cipher suites have known vulnerabilities|TLS_.*3DES|TLS_.*CBC"
+	"weak-cipher-rc4|CRITICAL|RC4 cipher suite|RC4 cipher is completely broken and must not be used|TLS_.*RC4"
+	"null-cipher|CRITICAL|NULL cipher suite|NULL ciphers provide no encryption|TLS_.*NULL"
+	"tls-profile-old|HIGH|Old TLS security profile|Old TLS profile allows insecure TLS 1.0 and 1.1|OldType|TLSProfileOldType"
+	"tls-profile-custom|MEDIUM|Custom TLS security profile|Custom TLS profile needs manual review for compliance|CustomType|TLSProfileCustomType"
 )

--- a/patterns/java.sh
+++ b/patterns/java.sh
@@ -12,4 +12,7 @@ JAVA_PATTERNS=(
 	"sslcontext-tlsv11|HIGH|SSLContext.getInstance TLSv1.1|TLS 1.1 has known vulnerabilities|SSLContext\.getInstance\(\"TLSv1\.1\"\)"
 	"enabled-weak-protocols|MEDIUM|setEnabledProtocols weak TLS|Enables deprecated TLS 1.0 or 1.1 protocols|setEnabledProtocols.*TLSv1[^.2-9]|setEnabledProtocols.*TLSv1\.1"
 	"sslcontext-tlsv13|INFO|SSLContext.getInstance TLSv1.3|Forces TLS 1.3 only (may break older clients)|SSLContext\.getInstance\(\"TLSv1\.3\"\)"
+	"weak-cipher-suite|HIGH|Weak JSSE cipher suite|Weak or insecure cipher suites enabled|setEnabledCipherSuites.*(DES|RC4|NULL|EXPORT|anon)"
+	"ssl-socket-factory-default|MEDIUM|Default SSLSocketFactory|Default SSLSocketFactory may use weak ciphers|SSLSocketFactory\.getDefault"
+	"pqc-ml-kem|INFO|PQC/ML-KEM patterns|Post-Quantum Cryptography adoption (ML-KEM)|(MLKEM|ML-KEM|postQuantum|post-quantum)"
 )

--- a/patterns/nodejs.sh
+++ b/patterns/nodejs.sh
@@ -11,4 +11,6 @@ NODEJS_PATTERNS=(
 	"min-version-weak|HIGH|minVersion TLS 1.0/1.1|Allows weak TLS versions|minVersion.*TLSv1[^.3]"
 	"max-version-tlsv12|MEDIUM|maxVersion TLSv1.2|Caps maximum TLS version at 1.2, preventing TLS 1.3|maxVersion.*TLSv1\.2"
 	"min-version-tlsv13|INFO|minVersion TLSv1.3|Forces TLS 1.3 (may break older clients)|minVersion.*TLSv1\.3"
+	"weak-cipher-config|HIGH|Weak cipher configuration|Weak or insecure ciphers in TLS options|ciphers.*(DES|RC4|NULL|EXPORT)"
+	"honor-cipher-order-false|MEDIUM|honorCipherOrder disabled|Server does not enforce cipher preference order|honorCipherOrder.*false"
 )

--- a/patterns/python.sh
+++ b/patterns/python.sh
@@ -12,4 +12,7 @@ PYTHON_PATTERNS=(
 	"protocol-tlsv11|HIGH|PROTOCOL_TLSv1_1|TLS 1.1 has known vulnerabilities|PROTOCOL_TLSv1_1"
 	"max-version-tlsv12|MEDIUM|maximum_version TLSv1_2|Caps maximum TLS version at 1.2, preventing TLS 1.3|maximum_version.*TLSv1_2"
 	"min-version-tlsv13|INFO|minimum_version TLSv1_3|Forces TLS 1.3 (may break older clients)|minimum_version.*TLSv1_3"
+	"weak-cipher-config|HIGH|Weak cipher configuration|Weak or insecure ciphers configured in SSL context|set_ciphers.*(DES|RC4|NULL|EXPORT|eNULL|aNULL)"
+	"no-default-ciphers|MEDIUM|Custom cipher configuration|Custom cipher string overrides defaults (review needed)|set_ciphers\("
+	"pqc-ml-kem|INFO|PQC/ML-KEM patterns|Post-Quantum Cryptography adoption (ML-KEM)|(mlkem|ML-KEM|post_quantum|post-quantum)"
 )

--- a/testdata/cpp/insecure.cpp
+++ b/testdata/cpp/insecure.cpp
@@ -39,3 +39,11 @@ void strict_tls() {
     // INFO: Forces TLS 1.3
     SSL_CTX_set_min_proto_version(ctx, TLS1_3_VERSION);
 }
+
+void weak_ciphers() {
+    SSL_CTX *ctx = SSL_CTX_new(TLS_method());
+    // HIGH: Weak OpenSSL ciphers
+    SSL_CTX_set_cipher_list(ctx, "DES-CBC3-SHA:RC4-SHA:NULL-SHA:EXPORT");
+    // HIGH: Weak TLS 1.3 ciphers
+    SSL_CTX_set_ciphersuites(ctx, "TLS_DES_CBC3_SHA:TLS_RC4_128_SHA:TLS_NULL_SHA");
+}

--- a/testdata/go/insecure.go
+++ b/testdata/go/insecure.go
@@ -45,3 +45,26 @@ func hardcodedConfig() *tls.Config {
 		MinVersion: tls.VersionTLS12,
 	}
 }
+
+func weakCiphers() *tls.Config {
+	// HIGH: 3DES cipher suite
+	// CRITICAL: RC4 cipher suite
+	// CRITICAL: NULL cipher suite
+	return &tls.Config{
+		CipherSuites: []uint16{
+			tls.TLS_RSA_WITH_3DES_EDE_CBC_SHA,
+			tls.TLS_RSA_WITH_RC4_128_SHA,
+			tls.TLS_RSA_WITH_NULL_SHA,
+		},
+	}
+}
+
+func oldTLSProfile() {
+	// HIGH: Old TLS profile allows TLS 1.0/1.1
+	profileType := configv1.OldType
+	_ = profileType
+
+	// MEDIUM: Custom profile needs review
+	customType := configv1.CustomType
+	_ = customType
+}

--- a/testdata/java/Insecure.java
+++ b/testdata/java/Insecure.java
@@ -53,4 +53,20 @@ public class Insecure {
         SSLContext ctx = SSLContext.getInstance("TLSv1.3");
         return ctx;
     }
+
+    // HIGH: Weak cipher suites
+    public void enableWeakCiphers(SSLSocket socket) {
+        socket.setEnabledCipherSuites(new String[]{"TLS_RSA_WITH_DES_CBC_SHA", "TLS_RSA_WITH_RC4_128_SHA", "TLS_RSA_WITH_NULL_SHA"});
+    }
+
+    // MEDIUM: Default SSLSocketFactory may use weak ciphers
+    public SocketFactory getFactory() {
+        return SSLSocketFactory.getDefault();
+    }
+
+    // INFO: PQC/ML-KEM adoption
+    public void postQuantumSetup() {
+        // Using MLKEM for post-quantum key exchange
+        KeyPairGenerator kpg = KeyPairGenerator.getInstance("MLKEM");
+    }
 }

--- a/testdata/nodejs/insecure.js
+++ b/testdata/nodejs/insecure.js
@@ -33,3 +33,13 @@ const options4 = {
 const options5 = {
   minVersion: 'TLSv1.3',
 };
+
+// HIGH: Weak cipher configuration
+const options6 = {
+  ciphers: 'DES-CBC3-SHA:RC4-SHA:NULL-SHA:EXPORT',
+};
+
+// MEDIUM: Server doesn't enforce cipher preference
+const options7 = {
+  honorCipherOrder: false,
+};

--- a/testdata/python/insecure.py
+++ b/testdata/python/insecure.py
@@ -28,3 +28,15 @@ ctx6.maximum_version = ssl.TLSVersion.TLSv1_2
 # INFO: Forces TLS 1.3
 ctx7 = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
 ctx7.minimum_version = ssl.TLSVersion.TLSv1_3
+
+# HIGH: Weak cipher configuration
+ctx8 = ssl.create_default_context()
+ctx8.set_ciphers("DES-CBC3-SHA:RC4-SHA:NULL-SHA")
+
+# MEDIUM: Custom cipher configuration (review needed)
+ctx9 = ssl.create_default_context()
+ctx9.set_ciphers("ECDHE+AESGCM:ECDHE+CHACHA20")
+
+# INFO: PQC/ML-KEM adoption
+import post_quantum
+mlkem_key = post_quantum.generate_mlkem_keypair()

--- a/tests/test_scanner.sh
+++ b/tests/test_scanner.sh
@@ -20,7 +20,7 @@ scan_language "$ROOT_DIR/testdata/go" "go" "" ""
 
 assert_greater_than "Go scan finds critical findings" 0 "$CRITICAL_COUNT"
 assert_greater_than "Go scan finds high findings" 0 "$HIGH_COUNT"
-assert_greater_than "Go scan finds total findings" 5 "$(get_findings_count)"
+assert_greater_than "Go scan finds total findings" 10 "$(get_findings_count)"
 
 # Verify specific findings
 found_insecure_skip=false
@@ -44,7 +44,7 @@ source "$ROOT_DIR/patterns/python.sh"
 scan_language "$ROOT_DIR/testdata/python" "python" "" ""
 
 assert_greater_than "Python scan finds critical findings" 0 "$CRITICAL_COUNT"
-assert_greater_than "Python scan finds total findings" 5 "$(get_findings_count)"
+assert_greater_than "Python scan finds total findings" 10 "$(get_findings_count)"
 
 # Reset state for Node.js
 FINDINGS=()
@@ -58,7 +58,7 @@ source "$ROOT_DIR/patterns/nodejs.sh"
 scan_language "$ROOT_DIR/testdata/nodejs" "nodejs" "" ""
 
 assert_greater_than "Node.js scan finds critical findings" 0 "$CRITICAL_COUNT"
-assert_greater_than "Node.js scan finds total findings" 4 "$(get_findings_count)"
+assert_greater_than "Node.js scan finds total findings" 7 "$(get_findings_count)"
 
 # Reset state for C++
 FINDINGS=()
@@ -72,7 +72,7 @@ source "$ROOT_DIR/patterns/cpp.sh"
 scan_language "$ROOT_DIR/testdata/cpp" "cpp" "" ""
 
 assert_greater_than "C++ scan finds critical findings" 0 "$CRITICAL_COUNT"
-assert_greater_than "C++ scan finds total findings" 5 "$(get_findings_count)"
+assert_greater_than "C++ scan finds total findings" 8 "$(get_findings_count)"
 
 # Reset state for Java
 FINDINGS=()
@@ -86,7 +86,7 @@ source "$ROOT_DIR/patterns/java.sh"
 scan_language "$ROOT_DIR/testdata/java" "java" "" ""
 
 assert_greater_than "Java scan finds critical findings" 0 "$CRITICAL_COUNT"
-assert_greater_than "Java scan finds total findings" 5 "$(get_findings_count)"
+assert_greater_than "Java scan finds total findings" 10 "$(get_findings_count)"
 
 # Reset state for exclude patterns test
 FINDINGS=()


### PR DESCRIPTION
## Summary

- Adds 15 new TLS anti-pattern detections across all 5 languages (34 → 49 total patterns), closing the three biggest feature gaps identified against tls-compliance-operator and certsuite
- **Cipher suite detection** (11 patterns): Flags weak/insecure ciphers (3DES, RC4, NULL, EXPORT) in Go, Python, Node.js, C++, and Java
- **OCP TLS Security Profile detection** (2 patterns, Go): Flags `OldType` (HIGH) and `CustomType` (MEDIUM) profile configurations
- **PQC/ML-KEM detection** expanded to Python and Java (2 patterns) — previously Go-only
- Fixes Java missing from language validation in `lib/config.sh`

## Test plan

- [x] `shfmt -d -i 0 -ci .` passes (no formatting issues)
- [x] `shellcheck -S warning` passes (no warnings)
- [x] `bash tests/run_tests.sh` passes all 70 tests with updated finding-count thresholds
- [x] Manual scan of testdata confirms all 15 new patterns produce findings
- [x] CI: ShellCheck, shfmt, unit tests (Ubuntu + macOS), self-test suite (default, SARIF, threshold, exclusion, single-language)