### PR TITLE
Fix grep output parsing for filenames containing colons

### DIFF
--- a/lib/scanner.sh
+++ b/lib/scanner.sh
@@ -126,16 +126,20 @@ scan_pattern() {
 	# Parse grep output lines: ./file:line:match
 	while IFS= read -r match_line; do
 		local file line_num match_text
-		# Extract file path (everything before first colon-number-colon)
-		file=$(echo "$match_line" | sed -E 's/:([0-9]+):.*$//')
-		line_num=$(echo "$match_line" | sed -E 's/^[^:]+:([0-9]+):.*$/\1/')
-		match_text=$(echo "$match_line" | sed -E 's/^[^:]+:[0-9]+://')
+		if [[ "$match_line" =~ ^(.*):([0-9]+):(.*)$ ]]; then
+			file="${BASH_REMATCH[1]}"
+			line_num="${BASH_REMATCH[2]}"
+			match_text="${BASH_REMATCH[3]}"
+		else
+			continue
+		fi
 
 		# Strip leading ./ from file path
 		file="${file#./}"
 
 		# Trim match text for readability
-		match_text=$(echo "$match_text" | sed 's/^[[:space:]]*//' | cut -c1-200)
+		match_text="${match_text#"${match_text%%[![:space:]]*}"}"
+		match_text="${match_text:0:200}"
 
 		FINDINGS+=("${pattern_id}|${severity}|${name}|${description}|${file}|${line_num}|${match_text}")
 

--- a/testdata/go/config:prod.go
+++ b/testdata/go/config:prod.go
@@ -1,0 +1,9 @@
+package main
+
+import "crypto/tls"
+
+func insecureColon() {
+	// This file has a colon in its name to test grep output parsing
+	cfg := &tls.Config{InsecureSkipVerify: true}
+	_ = cfg
+}

--- a/tests/test_scanner.sh
+++ b/tests/test_scanner.sh
@@ -32,6 +32,17 @@ for finding in "${FINDINGS[@]}"; do
 done
 assert_equals "Go scan detects InsecureSkipVerify" "true" "$found_insecure_skip"
 
+# Test: Files with colons in names are parsed correctly
+found_colon_file=false
+for finding in "${FINDINGS[@]}"; do
+	IFS='|' read -r _ _ _ _ ffile _ _ <<<"$finding"
+	if [[ "$ffile" == *"config:prod.go"* ]]; then
+		found_colon_file=true
+		break
+	fi
+done
+assert_equals "Scanner handles colons in filenames" "true" "$found_colon_file"
+
 # Reset state for Python
 FINDINGS=()
 CRITICAL_COUNT=0


### PR DESCRIPTION
## Summary

- Replace sed-based grep output parsing with bash regex matching (`BASH_REMATCH`) in `scan_pattern()` to correctly handle filenames containing colons (e.g., `config:prod.go`)
- The greedy `(.*)` before `:([0-9]+):` matches the last colon-digits-colon boundary instead of the first colon, fixing misattributed findings
- Eliminates 4 subshell spawns (3x sed + 1x sed|cut) per match line by using pure bash parameter expansion

## Test plan

- [x] Added `testdata/go/config:prod.go` test fixture with a colon in the filename
- [x] Added test assertion in `test_scanner.sh` verifying the finding is attributed to the correct file
- [x] All 98 existing tests pass
- [x] shellcheck and shfmt clean