### PR TITLE
Add false-positive test fixtures for all 6 languages

### DIFF
--- a/testdata/cpp/secure.cpp
+++ b/testdata/cpp/secure.cpp
@@ -1,0 +1,18 @@
+// Properly configured TLS - should not trigger critical/high findings.
+#include <openssl/ssl.h>
+
+// Always verify peer certificates.
+// Use TLS_method() for version-flexible negotiation.
+
+SSL_CTX* create_secure_context() {
+    SSL_CTX* ctx = SSL_CTX_new(TLS_method());
+    SSL_CTX_set_verify(ctx, SSL_VERIFY_PEER, NULL);
+    SSL_CTX_set_min_proto_version(ctx, TLS1_2_VERSION);
+    SSL_CTX_set_cipher_list(ctx, "HIGH:!MD5");
+    return ctx;
+}
+
+void log_status() {
+    printf("Certificate verification is enabled\n");
+    printf("Using modern TLS configuration\n");
+}

--- a/testdata/go/secure.go
+++ b/testdata/go/secure.go
@@ -1,0 +1,27 @@
+package secure
+
+import (
+	"crypto/tls"
+	"log"
+)
+
+// Properly configured TLS - none of these should trigger critical/high findings.
+
+func secureTLS() *tls.Config {
+	cfg := &tls.Config{
+		MinVersion: tls.VersionTLS12,
+	}
+	return cfg
+}
+
+func strictTLS() *tls.Config {
+	return &tls.Config{
+		InsecureSkipVerify: false,
+		MinVersion:         tls.VersionTLS12,
+	}
+}
+
+func warnUser() {
+	log.Println("Certificate verification is enabled")
+	log.Println("Using modern TLS version")
+}

--- a/testdata/java/Secure.java
+++ b/testdata/java/Secure.java
@@ -1,0 +1,20 @@
+package secure;
+
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.HttpsURLConnection;
+
+// Properly configured TLS - should not trigger critical/high findings.
+// Always use versioned SSLContext and default hostname verification.
+
+public class Secure {
+    public static SSLContext createSecureContext() throws Exception {
+        SSLContext ctx = SSLContext.getInstance("TLSv1.3");
+        ctx.init(null, null, null);
+        return ctx;
+    }
+
+    public static void logStatus() {
+        System.out.println("Certificate verification is enabled");
+        System.out.println("Hostname verification is active");
+    }
+}

--- a/testdata/nodejs/secure.js
+++ b/testdata/nodejs/secure.js
@@ -1,0 +1,19 @@
+// Properly configured TLS - should not trigger critical/high findings.
+
+const tls = require("tls");
+const https = require("https");
+
+// Certificate verification is enabled by default.
+// Always use modern TLS versions.
+
+const secureOptions = {
+  rejectUnauthorized: true,
+  minVersion: "TLSv1.3",
+};
+
+function logStatus() {
+  console.log("TLS verification is active");
+  console.log("Using secure protocol version");
+}
+
+const server = tls.createServer(secureOptions);

--- a/testdata/python/secure.py
+++ b/testdata/python/secure.py
@@ -1,0 +1,17 @@
+"""Properly configured TLS - should not trigger critical/high findings."""
+
+import ssl
+
+# Certificate verification must always be enabled.
+# Use PROTOCOL_TLS_CLIENT instead of legacy protocol constants.
+
+def create_secure_context():
+    ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+    ctx.verify_mode = ssl.CERT_REQUIRED
+    ctx.check_hostname = True
+    ctx.load_default_certs()
+    return ctx
+
+def log_status():
+    print("TLS verification is active")
+    print("Using secure cipher configuration")

--- a/testdata/rust/secure.rs
+++ b/testdata/rust/secure.rs
@@ -1,0 +1,19 @@
+// Properly configured TLS - should not trigger critical/high findings.
+// Always verify certificates and hostnames.
+// Use safe defaults from rustls.
+
+use rustls::ClientConfig;
+use std::sync::Arc;
+
+fn create_secure_config() -> Arc<ClientConfig> {
+    let config = ClientConfig::builder()
+        .with_safe_defaults()
+        .with_native_roots()
+        .with_no_client_auth();
+    Arc::new(config)
+}
+
+fn log_status() {
+    println!("Certificate verification is enabled");
+    println!("Using safe TLS defaults");
+}

--- a/tests/test_scanner.sh
+++ b/tests/test_scanner.sh
@@ -134,3 +134,96 @@ for finding in "${FINDINGS[@]+"${FINDINGS[@]}"}"; do
 	fi
 done
 assert_equals "Excluded pattern not found in results" "false" "$found_excluded"
+
+# --- False Positive Tests ---
+# Scan secure code files that should NOT trigger critical/high findings.
+# Each secure file contains comments and strings mentioning insecure patterns
+# plus properly configured TLS — none should produce critical/high matches.
+
+echo "  --- False Positive Tests ---"
+
+# Go secure code
+FINDINGS=()
+CRITICAL_COUNT=0
+HIGH_COUNT=0
+MEDIUM_COUNT=0
+INFO_COUNT=0
+fp_dir=$(mktemp -d)
+cp "$ROOT_DIR/testdata/go/secure.go" "$fp_dir/"
+source "$ROOT_DIR/patterns/go.sh"
+scan_language "$fp_dir" "go" "" ""
+assert_equals "Go secure code: no critical findings" "0" "$CRITICAL_COUNT"
+assert_equals "Go secure code: no high findings" "0" "$HIGH_COUNT"
+rm -rf "$fp_dir"
+
+# Python secure code
+FINDINGS=()
+CRITICAL_COUNT=0
+HIGH_COUNT=0
+MEDIUM_COUNT=0
+INFO_COUNT=0
+fp_dir=$(mktemp -d)
+cp "$ROOT_DIR/testdata/python/secure.py" "$fp_dir/"
+source "$ROOT_DIR/patterns/python.sh"
+scan_language "$fp_dir" "python" "" ""
+assert_equals "Python secure code: no critical findings" "0" "$CRITICAL_COUNT"
+assert_equals "Python secure code: no high findings" "0" "$HIGH_COUNT"
+rm -rf "$fp_dir"
+
+# Node.js secure code
+FINDINGS=()
+CRITICAL_COUNT=0
+HIGH_COUNT=0
+MEDIUM_COUNT=0
+INFO_COUNT=0
+fp_dir=$(mktemp -d)
+cp "$ROOT_DIR/testdata/nodejs/secure.js" "$fp_dir/"
+source "$ROOT_DIR/patterns/nodejs.sh"
+scan_language "$fp_dir" "nodejs" "" ""
+assert_equals "Node.js secure code: no critical findings" "0" "$CRITICAL_COUNT"
+assert_equals "Node.js secure code: no high findings" "0" "$HIGH_COUNT"
+rm -rf "$fp_dir"
+
+# C++ secure code
+FINDINGS=()
+CRITICAL_COUNT=0
+HIGH_COUNT=0
+MEDIUM_COUNT=0
+INFO_COUNT=0
+fp_dir=$(mktemp -d)
+cp "$ROOT_DIR/testdata/cpp/secure.cpp" "$fp_dir/"
+source "$ROOT_DIR/patterns/cpp.sh"
+scan_language "$fp_dir" "cpp" "" ""
+assert_equals "C++ secure code: no critical findings" "0" "$CRITICAL_COUNT"
+assert_equals "C++ secure code: no high findings" "0" "$HIGH_COUNT"
+rm -rf "$fp_dir"
+
+# Java secure code
+FINDINGS=()
+CRITICAL_COUNT=0
+HIGH_COUNT=0
+MEDIUM_COUNT=0
+INFO_COUNT=0
+fp_dir=$(mktemp -d)
+cp "$ROOT_DIR/testdata/java/Secure.java" "$fp_dir/"
+source "$ROOT_DIR/patterns/java.sh"
+scan_language "$fp_dir" "java" "" ""
+assert_equals "Java secure code: no critical findings" "0" "$CRITICAL_COUNT"
+assert_equals "Java secure code: no high findings" "0" "$HIGH_COUNT"
+rm -rf "$fp_dir"
+
+# Rust secure code
+FINDINGS=()
+CRITICAL_COUNT=0
+HIGH_COUNT=0
+# shellcheck disable=SC2034  # Used by scanner.sh
+MEDIUM_COUNT=0
+# shellcheck disable=SC2034  # Used by scanner.sh
+INFO_COUNT=0
+fp_dir=$(mktemp -d)
+cp "$ROOT_DIR/testdata/rust/secure.rs" "$fp_dir/"
+source "$ROOT_DIR/patterns/rust.sh"
+scan_language "$fp_dir" "rust" "" ""
+assert_equals "Rust secure code: no critical findings" "0" "$CRITICAL_COUNT"
+assert_equals "Rust secure code: no high findings" "0" "$HIGH_COUNT"
+rm -rf "$fp_dir"


### PR DESCRIPTION
## Summary

- Add `secure.*` test fixtures for Go, Python, Node.js, C++, Java, and Rust containing properly configured TLS code
- Each file uses secure APIs (e.g., `tls.VersionTLS12`, `ssl.CERT_REQUIRED`, `SSL_VERIFY_PEER`) that should not trigger critical/high findings
- Add 12 new assertions in `test_scanner.sh` verifying zero false positives per language
- Test count: 98 → 110

## Test plan

- [x] All 110 tests pass locally (macOS)
- [x] ShellCheck clean
- [x] shfmt clean

Closes #33