### PR TITLE
Add helpUri to SARIF rules for Code Scanning links

### DIFF
--- a/lib/sarif.sh
+++ b/lib/sarif.sh
@@ -45,11 +45,13 @@ generate_sarif() {
 			--arg name "$name" \
 			--arg desc "$description" \
 			--arg level "$sarif_level" \
+			--arg helpUri "https://github.com/sebrandon1/tls-config-lint/blob/main/docs/patterns.md" \
 			'. + [{
 				id: $id,
 				name: $name,
 				shortDescription: { text: $name },
 				fullDescription: { text: $desc },
+				helpUri: $helpUri,
 				defaultConfiguration: { level: $level },
 				properties: { tags: ["security", "tls"] }
 			}]')


### PR DESCRIPTION
## Summary

- Add `helpUri` field to each SARIF rule pointing to `docs/patterns.md`
- GitHub Code Scanning findings now link directly to pattern documentation

## Test plan

- [x] All 110 tests pass
- [x] ShellCheck and shfmt clean

Closes #18