### PR TITLE
Add config file path visibility in job summary

### DIFF
--- a/lib/config.sh
+++ b/lib/config.sh
@@ -17,9 +17,12 @@ parse_config_file() {
 
 	if [[ ! -f "$config_file" ]]; then
 		log_debug "No config file found at $config_file"
+		CONFIG_FILE_USED=""
 		return 0
 	fi
 
+	# shellcheck disable=SC2034  # Used by summary.sh
+	CONFIG_FILE_USED="$config_file"
 	log_msg "Reading config from $config_file"
 
 	local current_key=""

--- a/lib/summary.sh
+++ b/lib/summary.sh
@@ -14,6 +14,10 @@ generate_summary() {
 
 	summary+="## TLS Config Lint Results\n\n"
 
+	if [[ -n "${CONFIG_FILE_USED:-}" ]]; then
+		summary+="> Using config: \`$CONFIG_FILE_USED\`\n\n"
+	fi
+
 	if [[ "$total" -eq 0 ]]; then
 		summary+="**No TLS configuration issues found.**\n\n"
 	else


### PR DESCRIPTION
## Summary

- Show which config file is active in the job summary as a blockquote
- Example: `> Using config: .tls-config-lint.yml`
- Only shown when a config file is actually found and used

## Test plan

- [x] All 110 tests pass
- [x] ShellCheck and shfmt clean

Closes #22