### PR TITLE
Validate patterns variable name before eval

### DIFF
--- a/lib/scanner.sh
+++ b/lib/scanner.sh
@@ -246,7 +246,12 @@ scan_language() {
 		*) return 0 ;;
 	esac
 
-	# Use eval to iterate the named array (compatible with bash 3.x+)
+	# Validate variable name before eval (bash 3.x lacks declare -n)
+	if [[ ! "$patterns_var" =~ ^[A-Z_]+$ ]]; then
+		log_error "Invalid patterns variable name: $patterns_var"
+		return 1
+	fi
+
 	local pattern_line
 	eval 'for pattern_line in "${'"$patterns_var"'[@]}"; do
 		scan_pattern "$scan_path" "$lang" "$pattern_line" "$exclude_dirs" "$exclude_patterns"


### PR DESCRIPTION
## Summary

- Add a regex guard (`^[A-Z_]+$`) before the `eval` in `scan_language()` to prevent injection from malformed language names
- Keeps bash 3.x compatibility — `declare -n` (nameref) requires bash 4.3+ and fails on macOS default bash 3.2
- The case statement already constrains `patterns_var` to known values, but the guard adds defense-in-depth

## Test plan

- [x] All 110 tests pass
- [x] ShellCheck and shfmt clean

Closes #23
