### PR TITLE
Add gRPC insecure connection patterns for Go and Python

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A GitHub Action that scans your codebase for TLS configuration anti-patterns and
 
 ## Key Features
 
-- **82 TLS Anti-Patterns** — Across 6 languages with severity classification (critical, high, medium, info)
+- **84 TLS Anti-Patterns** — Across 6 languages with severity classification (critical, high, medium, info)
 - **Inline PR Annotations** — Findings appear directly on affected lines in pull requests
 - **SARIF Output** — Optional GitHub Code Scanning integration
 - **Auto-Detection** — Discovers project languages from file markers (go.mod, package.json, etc.)

--- a/docs/patterns.md
+++ b/docs/patterns.md
@@ -1,13 +1,13 @@
 # Detected Patterns
 
-tls-config-lint detects 82 TLS anti-patterns across 6 languages. Severity levels:
+tls-config-lint detects 84 TLS anti-patterns across 6 languages. Severity levels:
 
 - **CRITICAL** — Certificate verification disabled, NULL ciphers
 - **HIGH** — Weak TLS versions (1.0/1.1), broken ciphers
 - **MEDIUM** — Prevents TLS 1.3 adoption
 - **INFO** — Post-quantum cryptography, deprecated features
 
-## Go (16 patterns)
+## Go (17 patterns)
 
 | ID | Severity | Description |
 |----|----------|-------------|
@@ -27,8 +27,9 @@ tls-config-lint detects 82 TLS anti-patterns across 6 languages. Severity levels
 | `curve-preferences` | INFO | Explicit curve configuration |
 | `hardcoded-tls-config` | INFO | Hardcoded `tls.Config{}` |
 | `pqc-ml-kem` | INFO | Post-Quantum Cryptography adoption |
+| `grpc-insecure` | CRITICAL | gRPC connection without TLS (plaintext) |
 
-## Python (14 patterns)
+## Python (15 patterns)
 
 | ID | Severity | Description |
 |----|----------|-------------|
@@ -46,6 +47,7 @@ tls-config-lint detects 82 TLS anti-patterns across 6 languages. Severity levels
 | `urllib3-default-ciphers` | HIGH | Overrides global urllib3 cipher config |
 | `aiohttp-ssl-false` | CRITICAL | Disables verification in aiohttp |
 | `pqc-ml-kem` | INFO | Post-Quantum Cryptography adoption |
+| `grpc-insecure-channel` | CRITICAL | gRPC insecure channel (plaintext) |
 
 ## Node.js/TypeScript (12 patterns)
 

--- a/patterns/go.sh
+++ b/patterns/go.sh
@@ -20,4 +20,5 @@ GO_PATTERNS=(
 	"null-cipher|CRITICAL|NULL cipher suite|NULL ciphers provide no encryption|TLS_.*NULL"
 	"tls-profile-old|HIGH|Old TLS security profile|Old TLS profile allows insecure TLS 1.0 and 1.1|OldType|TLSProfileOldType"
 	"tls-profile-custom|MEDIUM|Custom TLS security profile|Custom TLS profile needs manual review for compliance|CustomType|TLSProfileCustomType"
+	"grpc-insecure|CRITICAL|gRPC insecure connection|gRPC connection without TLS (plaintext)|grpc\.WithInsecure()\|grpc\.Dial.*insecure\.NewCredentials()\|grpc\.NewClient.*insecure\.NewCredentials()"
 )

--- a/patterns/python.sh
+++ b/patterns/python.sh
@@ -18,4 +18,5 @@ PYTHON_PATTERNS=(
 	"urllib3-default-ciphers|HIGH|urllib3 DEFAULT_CIPHERS override|Overrides global urllib3 cipher configuration|util\.ssl_\.DEFAULT_CIPHERS[[:space:]]*="
 	"aiohttp-ssl-false|CRITICAL|aiohttp ssl=False|Disables TLS certificate verification in aiohttp|TCPConnector.*ssl[[:space:]]*=[[:space:]]*False\|ClientSession.*ssl[[:space:]]*=[[:space:]]*False"
 	"pqc-ml-kem|INFO|PQC/ML-KEM patterns|Post-Quantum Cryptography adoption (ML-KEM)|(mlkem|ML-KEM|post_quantum|post-quantum)"
+	"grpc-insecure-channel|CRITICAL|gRPC insecure channel|gRPC connection without TLS (plaintext)|grpc\.insecure_channel("
 )

--- a/testdata/go/insecure.go
+++ b/testdata/go/insecure.go
@@ -59,6 +59,16 @@ func weakCiphers() *tls.Config {
 	}
 }
 
+func insecureGRPC() {
+	// CRITICAL: gRPC without TLS
+	conn, _ := grpc.Dial("localhost:50051", grpc.WithInsecure())
+	_ = conn
+
+	// CRITICAL: gRPC with insecure.NewCredentials()
+	conn2, _ := grpc.Dial("localhost:50051", grpc.WithTransportCredentials(insecure.NewCredentials()))
+	_ = conn2
+}
+
 func oldTLSProfile() {
 	// HIGH: Old TLS profile allows TLS 1.0/1.1
 	profileType := configv1.OldType

--- a/testdata/python/insecure.py
+++ b/testdata/python/insecure.py
@@ -48,6 +48,10 @@ urllib3.util.ssl_.DEFAULT_CIPHERS = "ECDH+AESGCM"
 import aiohttp
 connector = aiohttp.TCPConnector(ssl = False)
 
+# CRITICAL: gRPC insecure channel (plaintext)
+import grpc
+channel = grpc.insecure_channel("localhost:50051")
+
 # INFO: PQC/ML-KEM adoption
 import post_quantum
 mlkem_key = post_quantum.generate_mlkem_keypair()


### PR DESCRIPTION
## Summary

- Add `grpc-insecure` pattern for Go: detects `grpc.WithInsecure()`, `insecure.NewCredentials()` via `grpc.Dial` and `grpc.NewClient`
- Add `grpc-insecure-channel` pattern for Python: detects `grpc.insecure_channel()`
- Both are CRITICAL severity — plaintext gRPC connections are a common anti-pattern in microservice architectures
- Add test fixtures in `testdata/go/insecure.go` and `testdata/python/insecure.py`
- Update pattern count: 82 -> 84

## Test plan

- [x] All 110 tests pass
- [x] ShellCheck and shfmt clean
- [x] Verified grep matches against testdata fixtures

Closes #24
