### PR TITLE
Add libcurl CURLOPT_SSL_VERIFYPEER/VERIFYHOST patterns for C++

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A GitHub Action that scans your codebase for TLS configuration anti-patterns and
 
 ## Key Features
 
-- **84 TLS Anti-Patterns** — Across 6 languages with severity classification (critical, high, medium, info)
+- **86 TLS Anti-Patterns** — Across 6 languages with severity classification (critical, high, medium, info)
 - **Inline PR Annotations** — Findings appear directly on affected lines in pull requests
 - **SARIF Output** — Optional GitHub Code Scanning integration
 - **Auto-Detection** — Discovers project languages from file markers (go.mod, package.json, etc.)

--- a/docs/patterns.md
+++ b/docs/patterns.md
@@ -1,6 +1,6 @@
 # Detected Patterns
 
-tls-config-lint detects 84 TLS anti-patterns across 6 languages. Severity levels:
+tls-config-lint detects 86 TLS anti-patterns across 6 languages. Severity levels:
 
 - **CRITICAL** — Certificate verification disabled, NULL ciphers
 - **HIGH** — Weak TLS versions (1.0/1.1), broken ciphers
@@ -66,7 +66,7 @@ tls-config-lint detects 84 TLS anti-patterns across 6 languages. Severity levels
 | `secure-protocol-weak` | HIGH | Weak TLS protocol in HTTPS options |
 | `min-version-tlsv13` | INFO | Forces TLS 1.3 |
 
-## C++ (10 patterns)
+## C++ (12 patterns)
 
 | ID | Severity | Description |
 |----|----------|-------------|
@@ -80,6 +80,8 @@ tls-config-lint detects 84 TLS anti-patterns across 6 languages. Severity levels
 | `weak-ciphersuites` | HIGH | Weak ciphers via `SSL_CTX_set_ciphersuites` |
 | `max-proto-tls12` | MEDIUM | Caps at TLS 1.2 |
 | `min-proto-tls13` | INFO | Forces TLS 1.3 |
+| `curl-ssl-verifypeer-off` | CRITICAL | `CURLOPT_SSL_VERIFYPEER` disabled (libcurl) |
+| `curl-ssl-verifyhost-off` | CRITICAL | `CURLOPT_SSL_VERIFYHOST` disabled (libcurl) |
 
 ## Java (16 patterns)
 

--- a/patterns/cpp.sh
+++ b/patterns/cpp.sh
@@ -14,4 +14,6 @@ CPP_PATTERNS=(
 	"min-proto-tls13|INFO|SSL_CTX_set_min_proto_version TLS1_3|Forces TLS 1.3 (may break older clients)|SSL_CTX_set_min_proto_version.*TLS1_3_VERSION"
 	"weak-cipher-list|HIGH|Weak OpenSSL cipher list|Weak ciphers configured via SSL_CTX_set_cipher_list|SSL_CTX_set_cipher_list.*(DES|RC4|NULL|EXPORT|eNULL|aNULL)"
 	"weak-ciphersuites|HIGH|Weak TLS 1.3 ciphersuites|Weak ciphers configured via SSL_CTX_set_ciphersuites|SSL_CTX_set_ciphersuites.*(DES|RC4|NULL)"
+	"curl-ssl-verifypeer-off|CRITICAL|CURLOPT_SSL_VERIFYPEER disabled|Disables libcurl peer certificate verification (MITM vulnerability)|CURLOPT_SSL_VERIFYPEER[[:space:]]*,[[:space:]]*0\|CURLOPT_SSL_VERIFYPEER[[:space:]]*,[[:space:]]*false\|CURLOPT_SSL_VERIFYPEER[[:space:]]*,[[:space:]]*FALSE"
+	"curl-ssl-verifyhost-off|CRITICAL|CURLOPT_SSL_VERIFYHOST disabled|Disables libcurl hostname verification (MITM vulnerability)|CURLOPT_SSL_VERIFYHOST[[:space:]]*,[[:space:]]*0\|CURLOPT_SSL_VERIFYHOST[[:space:]]*,[[:space:]]*false\|CURLOPT_SSL_VERIFYHOST[[:space:]]*,[[:space:]]*FALSE"
 )

--- a/testdata/cpp/insecure.cpp
+++ b/testdata/cpp/insecure.cpp
@@ -40,6 +40,14 @@ void strict_tls() {
     SSL_CTX_set_min_proto_version(ctx, TLS1_3_VERSION);
 }
 
+void insecure_curl() {
+    CURL *curl = curl_easy_init();
+    // CRITICAL: Disables peer certificate verification
+    curl_easy_setopt(curl, CURLOPT_SSL_VERIFYPEER, 0);
+    // CRITICAL: Disables hostname verification
+    curl_easy_setopt(curl, CURLOPT_SSL_VERIFYHOST, 0);
+}
+
 void weak_ciphers() {
     SSL_CTX *ctx = SSL_CTX_new(TLS_method());
     // HIGH: Weak OpenSSL ciphers


### PR DESCRIPTION
## Summary

- Add `curl-ssl-verifypeer-off` pattern: detects `CURLOPT_SSL_VERIFYPEER` set to 0/false/FALSE
- Add `curl-ssl-verifyhost-off` pattern: detects `CURLOPT_SSL_VERIFYHOST` set to 0/false/FALSE
- Both are CRITICAL severity — disabling libcurl verification is a common anti-pattern in C/C++ codebases
- Add test fixtures in `testdata/cpp/insecure.cpp`
- Update pattern count: 84 -> 86, C++ patterns: 10 -> 12

## Test plan

- [x] All 110 tests pass
- [x] ShellCheck and shfmt clean
- [x] Verified grep matches against testdata fixtures

Closes #32
