### PR TITLE
Add macOS to self-test CI matrix

### DIFF
--- a/.github/workflows/self-test.yml
+++ b/.github/workflows/self-test.yml
@@ -11,8 +11,11 @@ permissions:
 
 jobs:
   self-test-default:
-    name: Self Test (default settings)
-    runs-on: ubuntu-latest
+    name: Self Test (default settings, ${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
     steps:
       - uses: actions/checkout@v6
       - name: Run TLS Config Lint against testdata
@@ -97,10 +100,12 @@ jobs:
           echo "Findings after exclusion: ${{ steps.lint-exclude.outputs.findings-count }}"
 
   self-test-per-language:
-    name: Self Test (${{ matrix.language }})
-    runs-on: ubuntu-latest
+    name: Self Test (${{ matrix.language }}, ${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
+        os: [ubuntu-latest, macos-latest]
+        language: [go, python, nodejs, cpp, java, rust]
         include:
           - language: go
             scan-path: testdata/go


### PR DESCRIPTION
## Summary

- Add macOS to the default settings and per-language self-test matrices
- Catches BSD grep vs GNU grep behavioral differences (e.g., `-I` flag handling, regex engine quirks)
- Self-test jobs go from 15 to 23 (8 new macOS jobs: 2 default + 6 per-language)

## Test plan

- [x] All 110 unit tests pass
- [ ] All 23 self-test jobs pass in CI (first run validates macOS)

Closes #35
