### PR TITLE
Tech debt cleanup: SARIF tests, CI caching, release automation, docs fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,10 +26,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
+      - uses: actions/setup-go@v5
+        with:
+          go-version: stable
       - name: Install shfmt
-        run: |
-          go install mvdan.cc/sh/v3/cmd/shfmt@latest
-          echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
+        run: go install mvdan.cc/sh/v3/cmd/shfmt@latest
       - name: Check formatting
         run: shfmt -d -i 0 -ci .
 
@@ -38,10 +39,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - name: Install and run actionlint
-        run: |
-          bash <(curl -s https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
-          ./actionlint
+      - name: Run actionlint
+        uses: rhysd/actionlint@v1.7.12
 
   unit-tests:
     name: Unit Tests (${{ matrix.os }})

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,35 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Validate tag format
+        run: |
+          TAG_NAME="${GITHUB_REF#refs/tags/}"
+          if [[ ! "$TAG_NAME" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::Tag '$TAG_NAME' does not match semver format (vX.Y.Z)"
+            exit 1
+          fi
+          echo "TAG_NAME=$TAG_NAME" >> "$GITHUB_ENV"
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create "$TAG_NAME" \
+            --title "$TAG_NAME" \
+            --generate-notes

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-A pure bash GitHub Action (composite, no Docker) that scans codebases for TLS configuration anti-patterns across Go, Python, Node.js/TypeScript, C++, and Java using grep-based regex pattern matching.
+A pure bash GitHub Action (composite, no Docker) that scans codebases for TLS configuration anti-patterns across Go, Python, Node.js/TypeScript, C++, Java, and Rust using grep-based regex pattern matching.
 
 ## Commands
 
@@ -19,6 +19,7 @@ bash tests/test_detect.sh
 bash tests/test_utils.sh
 bash tests/test_annotations.sh
 bash tests/test_summary.sh
+bash tests/test_sarif.sh
 
 # Check formatting (shfmt: go install mvdan.cc/sh/v3/cmd/shfmt@latest)
 shfmt -d -i 0 -ci .
@@ -41,7 +42,7 @@ Pipeline orchestrated by `entrypoint.sh`:
 
 Findings accumulate in a global `FINDINGS` array as pipe-delimited strings: `"id|severity|name|description|file|line|match"`
 
-Pattern files (`patterns/{go,python,nodejs,cpp,java}.sh`) define arrays of `"id|severity|name|description|regex"` entries. Severity levels: CRITICAL (cert verification disabled), HIGH (weak TLS versions), MEDIUM (prevents TLS 1.3), INFO (PQC, deprecated features).
+Pattern files (`patterns/{go,python,nodejs,cpp,java,rust}.sh`) define arrays of `"id|severity|name|description|regex"` entries. Severity levels: CRITICAL (cert verification disabled), HIGH (weak TLS versions), MEDIUM (prevents TLS 1.3), INFO (PQC, deprecated features).
 
 ## Conventions
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ jobs:
 
 | Guide | Description |
 |-------|-------------|
-| [Detected Patterns](docs/patterns.md) | All 82 patterns across 6 languages |
+| [Detected Patterns](docs/patterns.md) | All 86 patterns across 6 languages |
 | [Configuration](docs/configuration.md) | Config file, advanced usage examples, exit codes |
 | [Built-in Exclusions](docs/exclusions.md) | Default excluded directories and test files |
 

--- a/lib/sarif.sh
+++ b/lib/sarif.sh
@@ -33,12 +33,7 @@ generate_sarif() {
 		seen_patterns+=("$pattern_id")
 
 		local sarif_level
-		case "$(normalize_severity "$severity")" in
-			critical | high) sarif_level="error" ;;
-			medium) sarif_level="warning" ;;
-			info) sarif_level="note" ;;
-			*) sarif_level="note" ;;
-		esac
+		sarif_level=$(severity_to_sarif_level "$severity")
 
 		rules_json=$(echo "$rules_json" | jq \
 			--arg id "$pattern_id" \
@@ -64,12 +59,7 @@ generate_sarif() {
 		IFS='|' read -r pattern_id severity name description file line_num match_text <<<"$finding"
 
 		local sarif_level
-		case "$(normalize_severity "$severity")" in
-			critical | high) sarif_level="error" ;;
-			medium) sarif_level="warning" ;;
-			info) sarif_level="note" ;;
-			*) sarif_level="note" ;;
-		esac
+		sarif_level=$(severity_to_sarif_level "$severity")
 
 		# Find rule index
 		local rule_index=0

--- a/lib/utils.sh
+++ b/lib/utils.sh
@@ -21,6 +21,15 @@ severity_level() {
 	esac
 }
 
+severity_to_sarif_level() {
+	case "$(normalize_severity "$1")" in
+		critical | high) echo "error" ;;
+		medium) echo "warning" ;;
+		info) echo "note" ;;
+		*) echo "note" ;;
+	esac
+}
+
 # Check if severity meets or exceeds threshold
 # Returns 0 (true) if finding_severity >= threshold_severity
 meets_threshold() {

--- a/tests/test_sarif.sh
+++ b/tests/test_sarif.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# test_sarif.sh - SARIF generator tests
+
+# Source library modules
+source "$ROOT_DIR/lib/utils.sh"
+source "$ROOT_DIR/lib/scanner.sh"
+source "$ROOT_DIR/lib/sarif.sh"
+
+echo "  --- SARIF Tests ---"
+
+sarif_out=$(mktemp)
+trap 'rm -f "$sarif_out"' RETURN
+
+# Test: Single finding produces correct rule and result
+FINDINGS=()
+FINDINGS+=("insecure-skip-verify|CRITICAL|InsecureSkipVerify|Disables certificate verification|main.go|42|InsecureSkipVerify: true")
+generate_sarif "$sarif_out" 2>/dev/null
+sarif_json=$(cat "$sarif_out")
+
+assert_equals "Single finding has one rule" "1" "$(echo "$sarif_json" | jq '.runs[0].tool.driver.rules | length')"
+assert_equals "Single finding has one result" "1" "$(echo "$sarif_json" | jq '.runs[0].results | length')"
+assert_equals "Rule ID matches pattern ID" "insecure-skip-verify" "$(echo "$sarif_json" | jq -r '.runs[0].tool.driver.rules[0].id')"
+assert_equals "Result ruleId matches" "insecure-skip-verify" "$(echo "$sarif_json" | jq -r '.runs[0].results[0].ruleId')"
+assert_equals "Result file matches" "main.go" "$(echo "$sarif_json" | jq -r '.runs[0].results[0].locations[0].physicalLocation.artifactLocation.uri')"
+assert_equals "Result line matches" "42" "$(echo "$sarif_json" | jq '.runs[0].results[0].locations[0].physicalLocation.region.startLine')"
+
+# Test: Duplicate pattern IDs produce deduplicated rules
+FINDINGS=()
+FINDINGS+=("insecure-skip-verify|CRITICAL|InsecureSkipVerify|Disables cert verification|main.go|10|code1")
+FINDINGS+=("insecure-skip-verify|CRITICAL|InsecureSkipVerify|Disables cert verification|handler.go|25|code2")
+FINDINGS+=("weak-tls-version|HIGH|WeakTLS|Uses TLS 1.0|server.go|50|code3")
+generate_sarif "$sarif_out" 2>/dev/null
+sarif_json=$(cat "$sarif_out")
+
+assert_equals "Deduplication: 2 unique rules from 3 findings" "2" "$(echo "$sarif_json" | jq '.runs[0].tool.driver.rules | length')"
+assert_equals "Deduplication: all 3 results present" "3" "$(echo "$sarif_json" | jq '.runs[0].results | length')"
+
+# Test: Severity mapping to SARIF levels
+FINDINGS=()
+FINDINGS+=("p-critical|CRITICAL|C|Desc|f.go|1|c")
+FINDINGS+=("p-high|HIGH|H|Desc|f.go|2|c")
+FINDINGS+=("p-medium|MEDIUM|M|Desc|f.go|3|c")
+FINDINGS+=("p-info|INFO|I|Desc|f.go|4|c")
+generate_sarif "$sarif_out" 2>/dev/null
+sarif_json=$(cat "$sarif_out")
+
+assert_equals "CRITICAL maps to error" "error" "$(echo "$sarif_json" | jq -r '.runs[0].results[0].level')"
+assert_equals "HIGH maps to error" "error" "$(echo "$sarif_json" | jq -r '.runs[0].results[1].level')"
+assert_equals "MEDIUM maps to warning" "warning" "$(echo "$sarif_json" | jq -r '.runs[0].results[2].level')"
+assert_equals "INFO maps to note" "note" "$(echo "$sarif_json" | jq -r '.runs[0].results[3].level')"
+
+# Test: Tool metadata
+assert_equals "Tool name is tls-config-lint" "tls-config-lint" "$(echo "$sarif_json" | jq -r '.runs[0].tool.driver.name')"
+assert_contains "Tool has informationUri" "github.com/sebrandon1/tls-config-lint" "$(echo "$sarif_json" | jq -r '.runs[0].tool.driver.informationUri')"
+
+# Test: Rules include helpUri
+assert_contains "Rules include helpUri" "docs/patterns.md" "$(echo "$sarif_json" | jq -r '.runs[0].tool.driver.rules[0].helpUri')"
+
+# Test: SARIF schema reference
+assert_contains "SARIF has schema reference" "sarif-schema-2.1.0" "$(echo "$sarif_json" | jq -r '.["$schema"]')"
+
+# Test: Result snippet is preserved
+FINDINGS=()
+FINDINGS+=("test-pattern|HIGH|Test|Desc|app.go|99|tls.Config{MinVersion: 0}")
+generate_sarif "$sarif_out" 2>/dev/null
+sarif_json=$(cat "$sarif_out")
+assert_equals "Snippet is preserved" "tls.Config{MinVersion: 0}" "$(echo "$sarif_json" | jq -r '.runs[0].results[0].locations[0].physicalLocation.region.snippet.text')"


### PR DESCRIPTION
## Summary

- Add 17 unit tests for `lib/sarif.sh` — the only lib module that had no dedicated test file. Tests cover single findings, rule deduplication, severity mapping, tool metadata, snippet preservation.
- Extract duplicate severity-to-SARIF-level case statement into shared `severity_to_sarif_level()` in `lib/utils.sh` (was duplicated at sarif.sh lines 36 and 67).
- Add release automation workflow (`.github/workflows/release.yml`) — creates a GitHub Release with auto-generated notes on semver tag push, chaining into existing `update-major-tag.yml`.
- Switch CI shfmt job to `actions/setup-go@v5` and actionlint to `rhysd/actionlint@v1.7.12` action (eliminates raw curl downloads).
- Fix README pattern count (82 → 86) and add Rust to CLAUDE.md language list.

## Test plan

- [x] All 127 tests pass (`bash tests/run_tests.sh`) — 17 new SARIF tests
- [x] `shfmt -d -i 0 -ci .` clean
- [x] `shellcheck -S warning` clean on all .sh files
- [ ] CI passes on GitHub